### PR TITLE
fix: return bound query runner from patched SelectQueryBuilder outside transactions

### DIFF
--- a/lib/helpers/patcher.helper.ts
+++ b/lib/helpers/patcher.helper.ts
@@ -35,7 +35,7 @@ function patchQueryRunner(repositoryType: unknown) {
                 const manager = getCurrentTransactionManager();
                 return manager?.mongoQueryRunner || manager?.queryRunner;
             }
-            return this.defaultManager;
+            return this.defaultQueryRunner;
         },
         set(queryRunner: QueryRunner | undefined) {
             this.defaultQueryRunner = queryRunner;

--- a/test/helpers/patcher.helper.spec.ts
+++ b/test/helpers/patcher.helper.spec.ts
@@ -63,18 +63,18 @@ describe('patcher.helper', () => {
             });
         });
 
-        it('returns the default manager outside a transaction', () => {
+        it('returns the bound query runner outside a transaction', () => {
             const qb = Object.create(SelectQueryBuilder.prototype);
-            const defaultManager = { id: 'default-manager' };
-            qb.defaultManager = defaultManager;
-            expect(qb.queryRunner).toBe(defaultManager);
-        });
-
-        it('stores assignments on the defaultQueryRunner field', () => {
-            const qb = Object.create(SelectQueryBuilder.prototype);
-            const queryRunner = { id: 'assigned' };
+            const queryRunner = { id: 'bound-qr' };
             qb.queryRunner = queryRunner;
             expect(qb.defaultQueryRunner).toBe(queryRunner);
+            expect(qb.queryRunner).toBe(queryRunner);
+        });
+
+        it('never resolves the query runner from the default manager outside a transaction', () => {
+            const qb = Object.create(SelectQueryBuilder.prototype);
+            qb.defaultManager = { id: 'default-manager' };
+            expect(qb.queryRunner).toBeUndefined();
         });
     });
 


### PR DESCRIPTION
The patched queryRunner getter returned this.defaultManager while the setter stored this.defaultQueryRunner, so every SelectQueryBuilder lost its bound query runner outside a transaction. With replication enabled, obtainQueryRunner() then fell back to a slave runner for ALL selects, including read-after-write reloads explicitly bound to a master runner (e.g. BaseRepository.runOnMaster), causing intermittent not-found errors under replica lag.